### PR TITLE
Add HTML support for title and message

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vue-confirm-dialog",
   "description": "simple action confirm",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "author": "Onur Aslan <aslanon.tr@gmail.com>",
   "private": false,
   "main": "dist/index.js",

--- a/src/vue-confirm-dialog.vue
+++ b/src/vue-confirm-dialog.vue
@@ -9,8 +9,8 @@
       <transition name="zoom">
         <div v-if="isShow" ref="vueConfirmDialog" class="vc-container">
           <span class="vc-text-grid">
-            <h4 v-if="dialog.title" class="vc-title">{{ dialog.title }}</h4>
-            <p v-if="dialog.message" class="vc-text">{{ dialog.message }}</p>
+            <h4 v-if="dialog.title" class="vc-title" v-html="dialog.title"></h4>
+            <p v-if="dialog.message" class="vc-text" v-html="dialog.message"></p>
             <span v-if="dialog.auth">
               <input
                 v-focus


### PR DESCRIPTION
Changed: use the `v-html` prop instead of the `{{dialog.title}}`, allowing the use of HTML tags.
There is an issue, marked as an enhancement - /issues/15 - that I think that this PR solves.

Note: Also bumped the version to 1.1.0 instead of 1.0.3 since I think this is a feature and not a bug fix.