### PR TITLE
Clicking on the buttons sends the form.

### DIFF
--- a/src/vue-confirm-dialog.vue
+++ b/src/vue-confirm-dialog.vue
@@ -32,6 +32,7 @@
               v-if="dialog.button.no"
               @click.stop="e => handleClickButton(e, false)"
               class="vc-btn left"
+              type="button"
             >
               {{ dialog.button.no }}
             </button>
@@ -41,6 +42,7 @@
               :disabled="dialog.auth ? !password : false"
               @click.stop="e => handleClickButton(e, true)"
               class="vc-btn"
+              type="button"
             >
               {{ dialog.button.yes }}
             </button>


### PR DESCRIPTION
I use Vue as a component mounted inside HTML form, for confirmation changes on the form inputs changes. I try to use VueConfirmDialog, but when clicking any button (yes or no) then submit my form.  `type=button` will be prevent this.